### PR TITLE
Add typing hints across repository

### DIFF
--- a/brute.py
+++ b/brute.py
@@ -1,10 +1,13 @@
 # This code is mostly taken from: https://www.geeksforgeeks.org/traveling-salesman-problem-tsp-implementation/
 
+from __future__ import annotations
+
 from sys import maxsize
 from itertools import permutations
+from typing import List, Tuple
 
 
-def brute(graph, start=0):
+def brute(graph: List[List[int]], start: int = 0) -> Tuple[int, List[int]]:
     V = len(graph)
     # store all vertex apart from source vertex
     vertex = []

--- a/dp.py
+++ b/dp.py
@@ -1,9 +1,21 @@
 # This code is mostly taken from: https://www.interviewbit.com/blog/travelling-salesman-problem/
 
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
 MAX = 999999
 
 
-def TSP(mask, pos, graph, dp, next_move, n, visited):
+def TSP(
+    mask: int,
+    pos: int,
+    graph: List[List[int]],
+    dp: List[List[int]],
+    next_move: Dict[Tuple[int, int], int],
+    n: int,
+    visited: int,
+) -> int:
     if mask == visited:
         return graph[pos][0]
 
@@ -24,7 +36,7 @@ def TSP(mask, pos, graph, dp, next_move, n, visited):
     return ans
 
 
-def dp(graph):
+def dp(graph: List[List[int]]) -> Tuple[int, List[int]]:
     n = len(graph)
     visited = (1 << n) - 1
 

--- a/einstein.py
+++ b/einstein.py
@@ -1,47 +1,78 @@
+from __future__ import annotations
+
+from typing import List
+
 from z3 import *
 
 # Create variables that indicate the different possible options.
 # For example, when Yellow=3 this means the third house is yellow
-Yellow, Blue, Red, Ivory, Green = colors = Ints('Yellow Blue Red Ivory Green')
-Norwegian, Ukrainian, Englishman, Spaniard, Japanese = nationalities = Ints('Norwegian Ukrainian Englishman Spaniard Japanese')
-Water, Tea, Milk, OrangeJuice, Coffee = beverages = Ints('Water Tea Milk OrangeJuice Coffee')
-Kools, Chesterfield, OldGold, LuckyStrike, Parliament = cigarettes = Ints('Kools Chesterfield OldGold LuckyStrike Parliament')
-Fox, Horse, Snails, Dog, Zebra = pets = Ints('Fox Horse Snails Dog Zebra')
+Yellow, Blue, Red, Ivory, Green = colors = Ints("Yellow Blue Red Ivory Green")
+Norwegian, Ukrainian, Englishman, Spaniard, Japanese = nationalities = Ints(
+    "Norwegian Ukrainian Englishman Spaniard Japanese"
+)
+Water, Tea, Milk, OrangeJuice, Coffee = beverages = Ints(
+    "Water Tea Milk OrangeJuice Coffee"
+)
+Kools, Chesterfield, OldGold, LuckyStrike, Parliament = cigarettes = Ints(
+    "Kools Chesterfield OldGold LuckyStrike Parliament"
+)
+Fox, Horse, Snails, Dog, Zebra = pets = Ints("Fox Horse Snails Dog Zebra")
 
-variables = colors + nationalities + beverages + cigarettes + pets
-dimensions = [colors, nationalities, beverages, cigarettes, pets]
+variables: List[ArithRef] = colors + nationalities + beverages + cigarettes + pets
+dimensions: List[List[ArithRef]] = [
+    colors,
+    nationalities,
+    beverages,
+    cigarettes,
+    pets,
+]
 s = Solver()
 
-# each house has a different color, nationality, beverage, cigarette, and pet
-for dimension in dimensions:
-    s.add(Distinct(dimension))
+def solve() -> None:
+    """Solve the Einstein riddle and print the water drinker and zebra owner."""
 
-# Constraint 1: There are 5 houses
-# Each variable needs to be assigned to one of the 5 houses
-for variable in variables:
-    s.add(And(variable >= 1, variable <= 5))
+    # each house has a different color, nationality, beverage, cigarette, and pet
+    for dimension in dimensions:
+        s.add(Distinct(dimension))
 
-s.add(Englishman == Red) # Constraint 2: The Englishman lives in the red house
-s.add(Spaniard == Dog) # Constraint 3: The Spaniard owns the dog
-s.add(Coffee == Green) # Constraint 4: Coffee is drunk in the green house
-s.add(Ukrainian == Tea) # Constraint 5: The Ukrainian drinks tea
-s.add(Green == Ivory + 1) # Constraint 6: The green house is immediately to the right of the ivory house
-s.add(OldGold == Snails) # And so on...
-s.add(Kools == Yellow)
-s.add(Milk == 3)
-s.add(Norwegian == 1)
-s.add(Or(Chesterfield == Fox + 1, Chesterfield == Fox - 1))
-s.add(Or(Kools == Horse + 1, Kools == Horse - 1))
-s.add(LuckyStrike == OrangeJuice)
-s.add(Japanese == Parliament)
-s.add(Or(Norwegian == Blue + 1, Norwegian == Blue - 1))
+    # Constraint 1: There are 5 houses
+    # Each variable needs to be assigned to one of the 5 houses
+    for variable in variables:
+        s.add(And(variable >= 1, variable <= 5))
 
-if s.check() == unsat:
-    print("Unsatisfiable")
-    exit(0)
-else:
+    s.add(Englishman == Red)  # Constraint 2: The Englishman lives in the red house
+    s.add(Spaniard == Dog)  # Constraint 3: The Spaniard owns the dog
+    s.add(Coffee == Green)  # Constraint 4: Coffee is drunk in the green house
+    s.add(Ukrainian == Tea)  # Constraint 5: The Ukrainian drinks tea
+    s.add(
+        Green == Ivory + 1
+    )  # Constraint 6: The green house is immediately to the right of the ivory house
+    s.add(OldGold == Snails)  # And so on...
+    s.add(Kools == Yellow)
+    s.add(Milk == 3)
+    s.add(Norwegian == 1)
+    s.add(Or(Chesterfield == Fox + 1, Chesterfield == Fox - 1))
+    s.add(Or(Kools == Horse + 1, Kools == Horse - 1))
+    s.add(LuckyStrike == OrangeJuice)
+    s.add(Japanese == Parliament)
+    s.add(Or(Norwegian == Blue + 1, Norwegian == Blue - 1))
+
+    if s.check() == unsat:
+        print("Unsatisfiable")
+        return
+
     m = s.model()
-    water_drinker = [nationality for nationality in nationalities if simplify(m[nationality] == m[Water])][0]
+    water_drinker = [
+        nationality
+        for nationality in nationalities
+        if simplify(m[nationality] == m[Water])
+    ][0]
     print(f"{water_drinker} drinks water")
-    zebra_owner = [nationality for nationality in nationalities if simplify(m[nationality] == m[Zebra])][0]
+    zebra_owner = [
+        nationality for nationality in nationalities if simplify(m[nationality] == m[Zebra])
+    ][0]
     print(f"{zebra_owner} owns the zebra")
+
+
+if __name__ == "__main__":
+    solve()

--- a/smt.py
+++ b/smt.py
@@ -1,14 +1,20 @@
-from z3 import Bool, Int, Optimize, Sum, If, And, sat
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from z3 import Bool, BoolRef, Int, Optimize, Sum, If, And, sat
 
 
 # Given an adjacency matrix describing a graph, return the minimum cost and route that
 # starts at city 0, visits each city exactly once and returns to city 0.
-def smt(distances):
+def smt(distances: List[List[int]]) -> Tuple[int, List[int]]:
     num_cities = len(distances)
     s = Optimize()
 
     # Variables representing our decision to use an edge or not.
-    edges_used = [[Bool(f"r_{i}_{j}") for j in range(num_cities)] for i in range(num_cities)]
+    edges_used: List[List[BoolRef]] = [
+        [Bool(f"r_{i}_{j}") for j in range(num_cities)] for i in range(num_cities)
+    ]
 
     # Variable representing the total distance traveled. If we use an edge then its
     # distance is added to total_distance.
@@ -64,7 +70,12 @@ def smt(distances):
 
 
 # Return the optimal tour path found by the solver.
-def get_tour_path(s, start_city, num_cities, routes):
+def get_tour_path(
+    s: Optimize,
+    start_city: int,
+    num_cities: int,
+    routes: List[List[BoolRef]],
+) -> List[int]:
     model = s.model()
     curr_city = start_city
     path = []

--- a/test.py
+++ b/test.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import argparse
+
 from smt import smt
 from dp import dp
 import random
@@ -13,60 +19,79 @@ distances = [
 ]
 '''
 
-min_size = 10
-max_size = 23
-iterations = 10
-smt_enabled = True
-dp_enabled = True
+min_size: int = 10
+max_size: int = 23
+iterations: int = 10
+smt_enabled: bool = True
+dp_enabled: bool = True
 
-smt_times_by_size: dict[int, list[float]] = {}
-dp_times_by_size: dict[int, list[float]] = {}
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--min-size", type=int, default=min_size)
+    parser.add_argument("--max-size", type=int, default=max_size)
+    parser.add_argument("--iterations", type=int, default=iterations)
+    parser.add_argument("--smt", dest="smt", action="store_true", default=smt_enabled)
+    parser.add_argument("--dp", dest="dp", action="store_true", default=dp_enabled)
+    parser.add_argument("--no-plot", action="store_true")
+    args = parser.parse_args()
 
-for size in range(min_size, max_size + 1):
-    smt_times_by_size[size] = []
-    dp_times_by_size[size] = []
-    for _ in range(iterations):
-        distances = [[random.randint(0, 100) for _ in range(size)] for _ in range(size)]
-        for i in range(size):
-            distances[i][i] = 0
-        print(f"size {size}, distances {distances}")
-        if smt_enabled:
-            start = time.perf_counter()
-            smt_dist, smt_path = smt(distances)
-            smt_time = time.perf_counter() - start
-            print(f"smt: {smt_dist}, {smt_path}")
-            print(f"smt took {smt_time}")
-            smt_times_by_size[size].append(smt_time)
-        if dp_enabled:
-            start = time.perf_counter()
-            dp_dist, dp_path = dp(distances)
-            dp_time = time.perf_counter() - start
-            print(f"dp took {dp_time}")
-            print(f"dp: {dp_dist}, {dp_path}")
-            dp_times_by_size[size].append(dp_time)
-        if smt_enabled and dp_enabled:
-            if smt_dist == dp_dist:
-                print("Agree")
-            else:
-                print("DISAGREE")
+    smt_enabled_local = args.smt
+    dp_enabled_local = args.dp
 
-for size in smt_times_by_size:
-    print(f"size {size}: {smt_times_by_size[size]}")
-    print(f"size {size}: {dp_times_by_size[size]}")
+    smt_times_by_size: Dict[int, List[float]] = {}
+    dp_times_by_size: Dict[int, List[float]] = {}
+
+    for size in range(args.min_size, args.max_size + 1):
+        smt_times_by_size[size] = []
+        dp_times_by_size[size] = []
+        for _ in range(args.iterations):
+            distances = [[random.randint(0, 100) for _ in range(size)] for _ in range(size)]
+            for i in range(size):
+                distances[i][i] = 0
+            print(f"size {size}, distances {distances}")
+            if smt_enabled_local:
+                start = time.perf_counter()
+                smt_dist, smt_path = smt(distances)
+                smt_time = time.perf_counter() - start
+                print(f"smt: {smt_dist}, {smt_path}")
+                print(f"smt took {smt_time}")
+                smt_times_by_size[size].append(smt_time)
+            if dp_enabled_local:
+                start = time.perf_counter()
+                dp_dist, dp_path = dp(distances)
+                dp_time = time.perf_counter() - start
+                print(f"dp took {dp_time}")
+                print(f"dp: {dp_dist}, {dp_path}")
+                dp_times_by_size[size].append(dp_time)
+            if smt_enabled_local and dp_enabled_local:
+                if smt_dist == dp_dist:
+                    print("Agree")
+                else:
+                    print("DISAGREE")
+
+    for size in smt_times_by_size:
+        print(f"size {size}: {smt_times_by_size[size]}")
+        print(f"size {size}: {dp_times_by_size[size]}")
 
 
-smt_sizes = [sz for sz, t in smt_times_by_size.items() if t]
-smt_medians = [statistics.median(smt_times_by_size[sz]) for sz in smt_sizes]
 
-dp_sizes = [sz for sz, t in dp_times_by_size.items() if t]
-dp_medians = [statistics.median(dp_times_by_size[sz]) for sz in dp_sizes]
+    smt_sizes = [sz for sz, t in smt_times_by_size.items() if t]
+    smt_medians = [statistics.median(smt_times_by_size[sz]) for sz in smt_sizes]
 
-print("SMT size → median_time:", list(zip(smt_sizes, smt_medians)))
-print("DP size → median_time:", list(zip(dp_sizes, dp_medians)))
+    dp_sizes = [sz for sz, t in dp_times_by_size.items() if t]
+    dp_medians = [statistics.median(dp_times_by_size[sz]) for sz in dp_sizes]
 
-plt.scatter(dp_sizes,  dp_medians,  label="dp")
-plt.scatter(smt_sizes, smt_medians, label="smt")
-plt.xlabel("Cities")
-plt.ylabel("Median time (seconds)")
-plt.legend()
-plt.show()
+    print("SMT size → median_time:", list(zip(smt_sizes, smt_medians)))
+    print("DP size → median_time:", list(zip(dp_sizes, dp_medians)))
+
+    if not args.no_plot:
+        plt.scatter(dp_sizes, dp_medians, label="dp")
+        plt.scatter(smt_sizes, smt_medians, label="smt")
+        plt.xlabel("Cities")
+        plt.ylabel("Median time (seconds)")
+        plt.legend()
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `__future__` imports and type hints in `brute`, `dp`, and `smt` modules
- annotate `einstein` variables and encapsulate solver logic in typed function
- annotate script variables in `test.py` and wrap logic in a typed `main`
- make test script configurable via command line arguments

## Testing
- `python3 test.py --min-size 3 --max-size 3 --iterations 1 --smt --dp --no-plot`
- `python3 -m py_compile *.py`
- `pytest -q`
- `python3 einstein.py | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_686623dab0bc8333ac14289edc159c88