### PR TITLE
Fix SMT solver single-city case

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -61,8 +61,8 @@ def main() -> None:
                 print(f"smt: {smt_dist}, {smt_path}")
                 print(f"smt took {smt_time}")
                 smt_times_by_size[size].append(smt_time)
-            if smt_modified_enabled_local:
-                # Force the 3rd city to always be second
+            # Force the 3rd city to always be second
+            if smt_modified_enabled_local and size >= 3:
                 required_orders = {2: 1}
                 start = time.perf_counter()
                 modified_dist, modified_path = smt(distances, required_orders)

--- a/smt.py
+++ b/smt.py
@@ -12,8 +12,9 @@ def smt(
     required_orders: Optional[Dict[int, int]] = None,
 ) -> Tuple[int, List[int]]:
     num_cities = len(distances)
+    if num_cities == 0:
+        return -1, []
     if num_cities == 1:
-        # Trivial case: start and end at the only city with zero cost
         return 0, [0, 0]
 
     s = Optimize()

--- a/smt.py
+++ b/smt.py
@@ -11,8 +11,11 @@ def smt(
     distances: List[List[int]],
     required_orders: Optional[Dict[int, int]] = None,
 ) -> Tuple[int, List[int]]:
-    
     num_cities = len(distances)
+    if num_cities == 1:
+        # Trivial case: start and end at the only city with zero cost
+        return 0, [0, 0]
+
     s = Optimize()
 
     # Variables representing our decision to use an edge or not.


### PR DESCRIPTION
## Summary
- handle the trivial case of a single city in the SMT solver

## Testing
- `python -m py_compile *.py`
- `python - <<'EOF'
from smt import smt
print('single city', smt([[0]]))
EOF`
- `python - <<'EOF'
from brute import brute
from dp import dp
from smt import smt
matrix=[[0,10,15,20],[10,0,35,25],[15,35,0,30],[20,25,30,0]]
print('brute', brute(matrix))
print('dp', dp(matrix))
print('smt', smt(matrix))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686655157f60833396746d0c5970bd14